### PR TITLE
Improve mavlink compatility performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,7 @@ tracing = "0.1"
 [[bench]]
 name = "bench"
 harness = false
+
+[[bench]]
+name = "compatibility_bench"
+harness = false

--- a/benches/compatibility_bench.rs
+++ b/benches/compatibility_bench.rs
@@ -1,0 +1,85 @@
+use criterion::{
+    black_box, criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion,
+    PlotConfiguration, Throughput,
+};
+use dev_utils::create_random_v2_raw_message;
+use mavlink_codec::v2::V2Packet;
+use rand::{prelude::StdRng, SeedableRng};
+
+fn benchmark_mavlink_compatibility(c: &mut Criterion) {
+    let seed = 42;
+    println!("Using seed {seed:?}");
+    let mut rng: StdRng = SeedableRng::seed_from_u64(seed);
+
+    let mut group = c.benchmark_group("mavlink_compatibility");
+    group.confidence_level(0.95).sample_size(100);
+
+    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+
+    group.plot_config(plot_config);
+
+    let messages_counts: Vec<usize> =
+        vec![1, 5, 10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000];
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    for messages_count in &messages_counts {
+        group.throughput(Throughput::Elements(*messages_count as u64));
+
+        let mut packets = Vec::with_capacity(*messages_count);
+        for _ in 0..*messages_count {
+            let mavlink_v2_message_raw = create_random_v2_raw_message(&mut rng);
+            let packet = V2Packet::from(mavlink_v2_message_raw);
+            packets.push(packet);
+        }
+
+        group.bench_with_input(
+            BenchmarkId::new("old", messages_count),
+            messages_count,
+            |b, &_messages_count| {
+                let packets = packets.clone();
+
+                b.to_async(&rt).iter(|| async {
+                    let mut packets = packets.clone();
+
+                    while let Some(packet) = packets.pop() {
+                        let _msg: Result<mavlink::MAVLinkV2MessageRaw, _> =
+                            black_box(try_from_first_implementation(packet));
+                    }
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("new", messages_count),
+            messages_count,
+            |b, &_messages_count| {
+                let packets = packets.clone();
+
+                b.to_async(&rt).iter(|| async {
+                    let mut packets = packets.clone();
+
+                    while let Some(packet) = packets.pop() {
+                        let _msg: Result<mavlink::MAVLinkV2MessageRaw, _> =
+                            black_box(V2Packet::try_into(packet));
+                    }
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn try_from_first_implementation(
+    value: V2Packet,
+) -> Result<mavlink::MAVLinkV2MessageRaw, mavlink::error::MessageReadError> {
+    use mavlink::ardupilotmega::MavMessage;
+
+    let mut reader = mavlink::peek_reader::PeekReader::new(value.as_slice());
+    let message = mavlink::read_v2_raw_message::<MavMessage, _>(&mut reader);
+    return message;
+}
+
+criterion_group!(benches, benchmark_mavlink_compatibility);
+criterion_main!(benches);

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -356,7 +356,7 @@ mod test {
 
         let v2_packet = V2Packet::from(raw_v2_message);
 
-        assert_eq!(v2_packet.header(), raw_v2_message.header()); // Todo: remote this clone once [this PR](https://github.com/mavlink/rust-mavlink/pull/288) get merged upstream
+        assert_eq!(v2_packet.header(), raw_v2_message.header());
         assert_eq!(*v2_packet.stx(), raw_v2_message.raw_bytes()[0]);
         assert_eq!(*v2_packet.payload_length(), raw_v2_message.payload_length());
         assert_eq!(

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -374,4 +374,30 @@ mod test {
         assert_eq!(v2_packet.payload(), raw_v2_message.payload());
         assert_eq!(v2_packet.checksum(), raw_v2_message.checksum());
     }
+
+    #[test]
+    fn test_raw_v2_message_from_v2packet() {
+        use mavlink::{ardupilotmega::MavMessage, MAVLinkV2MessageRaw, MavHeader, Message};
+
+        let raw_v2_message_original = {
+            let header = MavHeader {
+                system_id: 1,
+                component_id: 1,
+                sequence: 0,
+            };
+
+            let message_data = MavMessage::default_message_from_id(0).unwrap(); // Heartbeat message
+            let mut raw_v2_message = MAVLinkV2MessageRaw::new();
+            raw_v2_message.serialize_message(header, &message_data);
+            raw_v2_message
+        };
+
+        let v2_packet = V2Packet::from(raw_v2_message_original);
+
+        assert_eq!(v2_packet.as_slice(), raw_v2_message_original.raw_bytes());
+
+        let raw_v2_message = MAVLinkV2MessageRaw::try_from(v2_packet).unwrap();
+
+        assert_eq!(raw_v2_message_original, raw_v2_message);
+    }
 }


### PR DESCRIPTION
This patch improves by 96% the translation from Packet into rust-mavlink raw messages.

![image](https://github.com/user-attachments/assets/4c20861e-f708-4aac-9bf7-fd309da2b1dd)


## New:

<HTML>
<table>
    <thead>
        <tr>
            <th></th>
            <th title="0.95 confidence level">Lower bound</th>
            <th>Estimate</th>
            <th title="0.95 confidence level">Upper bound</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>Slope</td>
            <td>726.70 µs</td>
            <td>726.82 µs</td>
            <td>726.95 µs</td>
        </tr>
        <tr>
            <td>Throughput</td>
            <td>13.756 Melem/s</td>
            <td>13.759 Melem/s</td>
            <td>13.761 Melem/s</td>
        </tr>
        <tr>
            <td>R²</td>
            <td>0.9999140</td>
            <td>0.9999179</td>
            <td>0.9999132</td>
        </tr>
        <tr>
            <td>Mean</td>
            <td>726.81 µs</td>
            <td>727.06 µs</td>
            <td>727.41 µs</td>
        </tr>
        <tr>
            <td title="Standard Deviation">Std. Dev.</td>
            <td>625.11 ns</td>
            <td>1.5624 µs</td>
            <td>2.4654 µs</td>
        </tr>
        <tr>
            <td>Median</td>
            <td>726.57 µs</td>
            <td>726.64 µs</td>
            <td>726.80 µs</td>
        </tr>
        <tr>
            <td title="Median Absolute Deviation">MAD</td>
            <td>271.57 ns</td>
            <td>391.99 ns</td>
            <td>571.30 ns</td>
        </tr>
    </tbody>
</table>
</HTML>

## Old:

<HTML>
<table>
    <thead>
        <tr>
            <th></th>
            <th title="0.95 confidence level">Lower bound</th>
            <th>Estimate</th>
            <th title="0.95 confidence level">Upper bound</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>Slope</td>
            <td>1.4197 ms</td>
            <td>1.4202 ms</td>
            <td>1.4207 ms</td>
        </tr>
        <tr>
            <td>Throughput</td>
            <td>7.0389 Melem/s</td>
            <td>7.0414 Melem/s</td>
            <td>7.0436 Melem/s</td>
        </tr>
        <tr>
            <td>R²</td>
            <td>0.9993518</td>
            <td>0.9993660</td>
            <td>0.9993493</td>
        </tr>
        <tr>
            <td>Mean</td>
            <td>1.4235 ms</td>
            <td>1.4257 ms</td>
            <td>1.4282 ms</td>
        </tr>
        <tr>
            <td title="Standard Deviation">Std. Dev.</td>
            <td>8.1967 µs</td>
            <td>12.247 µs</td>
            <td>15.793 µs</td>
        </tr>
        <tr>
            <td>Median</td>
            <td>1.4200 ms</td>
            <td>1.4206 ms</td>
            <td>1.4216 ms</td>
        </tr>
        <tr>
            <td title="Median Absolute Deviation">MAD</td>
            <td>2.2494 µs</td>
            <td>3.0565 µs</td>
            <td>4.7240 µs</td>
        </tr>
    </tbody>
</table>
</HTML>

